### PR TITLE
added exception handler

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -6,6 +6,7 @@ use ReflectionMethod;
 use Illuminate\Support\Str;
 use Illuminate\Routing\Route;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Log;
 
 class Generator
 {
@@ -178,7 +179,13 @@ class Generator
 
         $parsedAction = Str::parseCallback($this->action);
 
-        $reflector = (new ReflectionMethod($parsedAction[0], $parsedAction[1]));
+         try {
+            $reflector = new ReflectionMethod($parsedAction[0], $parsedAction[1]);
+        } catch (\ReflectionException $e) {
+            Log::info('Parsed Action:', $parsedAction); // No need to wrap in array
+            Log::error('ReflectionException: ' . $e->getMessage()); // Use Log::error for exceptions
+            return false;
+        }
         $parameters = $reflector->getParameters();
         $docComment = $reflector->getDocComment();
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -182,8 +182,8 @@ class Generator
          try {
             $reflector = new ReflectionMethod($parsedAction[0], $parsedAction[1]);
         } catch (\ReflectionException $e) {
-            Log::info('Parsed Action:', $parsedAction); // No need to wrap in array
-            Log::error('ReflectionException: ' . $e->getMessage()); // Use Log::error for exceptions
+            Log::info('Parsed Action:', $parsedAction);
+            Log::error('ReflectionException: ' . $e->getMessage());
             return false;
         }
         $parameters = $reflector->getParameters();


### PR DESCRIPTION
add exception handler for this kind of case, because it cause the generation of doc to break

Route::get('/', function () {
    return [
        'message' => 'Welcome to v2 endpoint',
        'version' => '2.0'
    ];
});